### PR TITLE
Add FNF HTML demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@
 </div>
 
 ###
+
+## FNF Engine HTML Demo
+This repository now includes a small Friday Night Funkin' inspired demo using HTML, CSS and JavaScript.
+Open `index.html` in a browser to try it out.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>FNF HTML Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="info">
+    <h1>FNF Engine Demo (HTML)</h1>
+    <p id="mod-info">Inspired by the "Arrow-Based Vocals" mod (GameBanana ID 166759) which "Generates vocals based on the arrows in a chart".</p>
+    <p>Press arrow keys to hit notes as they pass the hit zone.</p>
+  </div>
+  <canvas id="gameCanvas" width="800" height="600"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,82 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+const laneWidth = canvas.width / 4;
+const hitZoneY = canvas.height - 100;
+let arrows = [];
+let lastSpawn = 0;
+let score = 0;
+
+function spawnArrow() {
+  const dirIndex = Math.floor(Math.random() * 4);
+  arrows.push({ x: dirIndex * laneWidth + laneWidth / 2, y: 0, dir: ['left','down','up','right'][dirIndex] });
+}
+
+function drawArrow(arrow) {
+  ctx.fillStyle = 'white';
+  ctx.beginPath();
+  ctx.moveTo(arrow.x, arrow.y);
+  ctx.lineTo(arrow.x - 20, arrow.y - 30);
+  ctx.lineTo(arrow.x + 20, arrow.y - 30);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function update(dt) {
+  if (Date.now() - lastSpawn > 800) {
+    spawnArrow();
+    lastSpawn = Date.now();
+  }
+  arrows.forEach(a => a.y += dt * 0.3);
+  arrows = arrows.filter(a => a.y < canvas.height + 40);
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = '#555';
+  for (let i=1;i<4;i++) {
+    ctx.beginPath();
+    ctx.moveTo(i*laneWidth, 0);
+    ctx.lineTo(i*laneWidth, canvas.height);
+    ctx.stroke();
+  }
+  ctx.fillStyle = '#444';
+  ctx.fillRect(0, hitZoneY-10, canvas.width, 20);
+  arrows.forEach(drawArrow);
+  ctx.fillStyle = 'white';
+  ctx.fillText('Score: '+score, 10, 20);
+}
+
+function gameLoop() {
+  const now = Date.now();
+  const dt = now - (gameLoop.last || now);
+  gameLoop.last = now;
+  update(dt);
+  draw();
+  requestAnimationFrame(gameLoop);
+}
+
+document.addEventListener('keydown', e => {
+  const dirMap = {
+    ArrowLeft: 'left',
+    ArrowDown: 'down',
+    ArrowUp: 'up',
+    ArrowRight: 'right'
+  };
+  const dir = dirMap[e.code];
+  if (!dir) return;
+  let hit = false;
+  arrows.forEach((a, idx) => {
+    if (a.dir === dir && Math.abs(a.y - hitZoneY) < 40) {
+      arrows.splice(idx,1);
+      score++;
+      hit = true;
+      const utter = new SpeechSynthesisUtterance(dir);
+      speechSynthesis.speak(utter);
+    }
+  });
+  if (!hit) {
+    score = Math.max(0, score-1);
+  }
+});
+
+gameLoop();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,15 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #111;
+  color: #eee;
+  text-align: center;
+}
+#gameCanvas {
+  background: #000;
+  display: block;
+  margin: 0 auto;
+  border: 2px solid #555;
+}
+#info {
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- add simple HTML/CSS/JS demo replicating basic FNF arrows
- mention new demo in README

## Testing
- `grep -o "Generates vocals based on the arrows in a chart.*" -m 1 <(curl -L https://gamebanana.com/mods/166759)`

------
https://chatgpt.com/codex/tasks/task_e_6845cc495d9c8323a631a0bf4e489866